### PR TITLE
added pre and post listenTo hooks

### DIFF
--- a/src/ListenerMethods.js
+++ b/src/ListenerMethods.js
@@ -149,12 +149,12 @@ module.exports = {
             var index = subs.indexOf(subscriptionobj);
             _.throwIf(index === -1, "Tried to remove listen already gone from subscriptions list!");
             if(this.listenable && this.listenable.preStopListenedTo){
-                this.listenable.preStopListenedTo.apply(this.listenable,arguments);
+                this.listenable.preStopListenedTo.apply(this.listenable, arguments);
             }
             subs.splice(index, 1);
             desub();
             if(this.listenable && this.listenable.postStopListenedTo){
-                this.listenable.postStopListenedTo.apply(this.listenable,arguments);
+                this.listenable.postStopListenedTo.apply(this.listenable, arguments);
             }
 
         };

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -3,7 +3,7 @@ var _ = require("./utils"),
     mixer = require("./mixer"),
     bindMethods = require("./bindMethods");
 
-var allowed = { preEmit: 1, shouldEmit: 1 };
+var allowed = { preEmit: 1, shouldEmit: 1, preListenedTo: 1, preStopListenedTo: 1, postListenedTo: 1, postStopListenedTo: 1 };
 
 /**
  * Creates an event emitting Data Store. It is mixed in with functions


### PR DESCRIPTION
I added some event listener hooks. Specifically, I was hoping to use these for stores and track how many listeners I have per store. I was going to combine this with socket io to subscribe and unsubscribe when listeners were active.

If needed, I can add documentation and an example use case with a store.
