### PR TITLE
Reducers

### DIFF
--- a/docs/api/Reflux.md
+++ b/docs/api/Reflux.md
@@ -30,6 +30,28 @@ Creates an event emitting Data Store. It is mixed in with functions from the `Li
 
 @returns {Store} A data store instance
 
+## Reflux.createReducer(initialData)
+
+Creates a reducer, a data store that uses pure functions to mutate the data.
+
+@param {Mixed} initialData the initial data to seed the reducer
+
+@returns {Reducer} A reducer instance
+
+@example
+```javascript
+var addUser = Reflux.createAction({ sync: true });
+var reducer = Reflux.createReducer({ users: [] });
+
+reducer.on(addUser, function(data, newUser) {
+  data.users.push(newUser);
+  return data;
+})
+
+addUser("John Doe");
+reducer.peek(); // outputs { users: ["John Doe"] }
+```
+
 ## Reflux.joinTrailing(...publishers)
 
 Creates a static join for the given publishers. It emits when all the publishers have emitted at least once, and will emit with the data that was last emitted by each listenable.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "benchmark": "node test/benchmarks",
     "watch:lint": "esw -w",
     "watch:test": "mocha -w -R min --compilers js:babel-core/register ./test",
-    "watch": "parallelshell 'npm run watch:test' 'npm run watch:lint'",
+    "watch": "parallelshell 'npm run watch:lint' 'npm run watch:test'",
     "prepublish": "npm run lint && npm run test:mocha && npm run clean && npm run compile",
     "precommit": "npm run lint && npm run test:mocha",
     "prepush": "npm run precommit"

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -1,0 +1,27 @@
+import * as _ from "./utils";
+import PublisherMethods from "./PublisherMethods";
+
+export default function createReducer(initialData) {
+
+    var data = initialData;
+
+    function Reducer() {
+        this.emitter = new _.EventEmitter();
+        this.eventLabel = "reducer";
+    }
+
+    Reducer.prototype.on = function(publisher, reducerFn) {
+        publisher.listen(function() {
+            data = reducerFn.apply(this, [ data, ...arguments ]);
+            this.trigger(data);
+        }, this);
+    };
+
+    Reducer.prototype.peek = function() {
+        return data;
+    };
+
+    _.extend(Reducer.prototype, PublisherMethods);
+
+    return new Reducer();
+}

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ import * as _ from "./utils";
 const utils = _;
 import createAction from "./createAction";
 import createStore from "./createStore";
+import createReducer from "./createReducer";
 
 /**
  * Convenience function for creating a set of actions
@@ -83,6 +84,7 @@ export default {
     utils,
     createAction,
     createStore,
+    createReducer,
     createActions,
     setEventEmitter,
     nextTick,

--- a/test/creatingReducers.spec.js
+++ b/test/creatingReducers.spec.js
@@ -1,0 +1,46 @@
+import chai, { assert } from 'chai';
+import asPromised from 'chai-as-promised';
+import Reflux from "../src";
+import sinon from "sinon";
+
+chai.use(asPromised);
+
+describe('with a reducer', function() {
+    describe('that has initial data', function() {
+        var reducer, initialData;
+
+        beforeEach(() => {
+            initialData = {
+                datum: 1337
+            };
+            reducer = Reflux.createReducer(initialData);
+        });
+
+        it('should be able to peek the data', function() {
+            assert.equal(initialData.datum, reducer.peek().datum);
+        });
+
+        describe('hooked to an action', function() {
+            var action, listener;
+
+            beforeEach(() => {
+                action = Reflux.createAction({sync: true});
+                listener = sinon.spy();
+                reducer.listen(listener);
+            });
+
+            it('should pass previous data as first argument', function() {
+                reducer.on(action, (a) => a);
+                action();
+                return assert.deepEqual(listener.args[0][0], initialData);
+            });
+
+            it('should pass arguments to the rest', function() {
+                reducer.on(action, (a, b, c) => { return {b: b, c: c}; });
+                action("dude", 1337);
+                return assert.deepEqual(reducer.peek(), {b: "dude", c: 1337});
+            });
+
+        });
+    });
+});


### PR DESCRIPTION
Adds createReducer function for creating a data store that uses pure functions to alter it's state. Much like the reduce function in lodash/underscore.
## Usage:

``` javascript
var addUser = Reflux.createAction({ sync: true });
var reducer = Reflux.createReducer({ users: [] });

reducer.on(addUser, function(data, newUser) {
  data.users.push(newUser);
  return data;
})

addUser("John Doe");
reducer.peek(); // outputs { users: ["John Doe"] }
```
## Todo:
- [ ] Either implement getInitialState or let react mixins look at the `peek` function instead.
- [ ] Should I add an unsubscribe function?
