### PR TITLE
fix extend in utils.js

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,7 @@ export function callbackName(string, prefix) {
 }
 
 /*
- * isObject, extend, isFunction, isArguments are taken from undescore/lodash in
+ * isObject, extend, isFunction, isArguments are taken from underscore/lodash in
  * order to remove the dependency
  */
 export function isObject(obj) {
@@ -20,10 +20,12 @@ export function extend(obj) {
     if (!isObject(obj)) {
         return obj;
     }
-    var source, prop;
+    var source, keys, prop;
     for (var i = 1, length = arguments.length; i < length; i++) {
         source = arguments[i];
-        for (prop in source) {
+        keys = Object.keys(source);
+        for (var j = 0; j < keys.length; j++) {
+            prop = keys[j];
             if (Object.getOwnPropertyDescriptor && Object.defineProperty) {
                 var propertyDescriptor = Object.getOwnPropertyDescriptor(source, prop);
                 Object.defineProperty(obj, prop, propertyDescriptor);


### PR DESCRIPTION
I was playing around with mixins which inherited from other mixins via prototype, and I got an error from Reflux. [This line](https://github.com/reflux/reflux-core/blob/b4132ec1f0/src/utils.js#L29) is throwing this error: "TypeError: Property description must be an object: undefined". The issue is that the version of `_.extend` in utils.js uses `for..in` (which iterates over all enumerable properties, including inherited ones) in conjunction with `Object.getOwnPropertyDescriptor()` (which returns `undefined` on inherited properties).

The current version of `lodash.extend`, uses `Object.keys()` (which returns only own enumerable properties). Combining mixin-style inheritance with prototype-style inheritance seems pretty silly, so It seems fine to me to use `Object.keys()` instead of `for...in`.
