### PR TITLE
workaround for ie8 and uglified compilations of the code.

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -52,7 +52,7 @@ export default function createAction(definition) {
         _isAction: true
     }, PublisherMethods, ActionMethods, definition);
 
-    var functor = function() {
+    var functor = function _functor () {
         var triggerType = functor.sync ? "trigger" : "triggerAsync";
         return functor[triggerType].apply(functor, arguments);
     };


### PR DESCRIPTION
By giving a name to a previously anonymous function, /lib/createAction.js
can be minifized safely for ie8.

More info: https://github.com/reflux/reflux-core/issues/16
