### PR TITLE
add asyncCall as an action parameter, 

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -36,7 +36,7 @@ export default function createAction(definition) {
     }
 
     definition.children = definition.children || [];
-    if (definition.asyncResult){
+    if (definition.asyncResult || definition.asyncCall){
         definition.children = definition.children.concat(["completed", "failed"]);
     }
 
@@ -52,6 +52,14 @@ export default function createAction(definition) {
         _isAction: true
     }, PublisherMethods, ActionMethods, definition);
 
+
+    if(definition.asyncCall){
+        context.listen( (argument) => {
+            definition.asyncCall(argument)
+                .then(definition.children.completed)
+                .catch(definition.children.failed);
+        });
+    }
     var functor = function() {
         var triggerType = functor.sync ? "trigger" : "triggerAsync";
         return functor[triggerType].apply(functor, arguments);

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -51,6 +51,13 @@ describe('Creating action', function() {
         });
     });
 
+    it.only("should create action with the parameter asyncCall",function(done){
+        let doLogin = () => {
+            done();
+        };
+        let actions = Reflux.createActions({login: {asyncCall: doLogin }});
+        actions.login();
+    });
     describe('Reflux.ActionMethods', function() {
 
         afterEach(function(){

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -51,7 +51,7 @@ describe('Creating action', function() {
         });
     });
 
-    it.only("should create action with the parameter asyncCall",function(done){
+    it("should create action with the parameter asyncCall",function(done){
         let doLogin = () => {
             done();
         };


### PR DESCRIPTION
The idea behind this PR is to avoid calling directly _listenAndPromise_, instead,  pass the function as a  new action parameter `asyncCall`
Before:

```
let actions = Reflux.createActions({
    signupOrLoginThirdParty: { asyncResult: true },
    signupLocal: { asyncResult: true }
} );

actions.signupOrLoginThirdParty.listenAndPromise( auth.signupOrLoginThirdParty );
actions.signupLocal.listenAndPromise( auth.signupLocal );
```

After:

```
let actions = Reflux.createActions({
    signupOrLoginThirdParty: { asyncCall:  auth.signupOrLoginThirdParty },
    signupLocal: { asyncCall: auth.signupLocal }
} );
```
