### PR TITLE
Crash when calling "stopListeningToAll" on a store listening to other stores

### DIFF
--- a/src/ListenerMethods.js
+++ b/src/ListenerMethods.js
@@ -119,9 +119,10 @@ export default {
         this.fetchInitialState(listenable, defaultCallback);
         desub = listenable.listen(this[callback] || callback, this);
         unsubscriber = function(listenerSubs) {
-            var index = listenerSubs.indexOf(subscriptionobj);
+            var currentSubs = listenerSubs ? listenerSubs : subs;
+            var index = currentSubs.indexOf(subscriptionobj);
             _.throwIf(index === -1, "Tried to remove listen already gone from subscriptions list!");
-            listenerSubs.splice(index, 1);
+            currentSubs.splice(index, 1);
             desub();
         };
         subscriptionobj = {

--- a/src/ListenerMethods.js
+++ b/src/ListenerMethods.js
@@ -118,10 +118,10 @@ export default {
         _.throwIf(this.validateListening(listenable));
         this.fetchInitialState(listenable, defaultCallback);
         desub = listenable.listen(this[callback] || callback, this);
-        unsubscriber = function() {
-            var index = subs.indexOf(subscriptionobj);
+        unsubscriber = function(listenerSubs) {
+            var index = listenerSubs.indexOf(subscriptionobj);
             _.throwIf(index === -1, "Tried to remove listen already gone from subscriptions list!");
-            subs.splice(index, 1);
+            listenerSubs.splice(index, 1);
             desub();
         };
         subscriptionobj = {
@@ -143,7 +143,7 @@ export default {
         for(;i < subs.length; i++){
             sub = subs[i];
             if (sub.listenable === listenable){
-                sub.stop();
+                sub.stop(subs);
                 _.throwIf(subs.indexOf(sub) !== -1, "Failed to remove listen from subscriptions list!");
                 return true;
             }
@@ -157,7 +157,7 @@ export default {
     stopListeningToAll: function(){
         var remaining, subs = this.subscriptions || [];
         while((remaining = subs.length)){
-            subs[0].stop();
+            subs[0].stop(subs);
             _.throwIf(subs.length !== remaining - 1, "Failed to remove listen from subscriptions list!");
         }
     },


### PR DESCRIPTION
I don't know if this is the correct way of doing this.

Encountered a crash when calling the function "stopListeningToAll" on a store that listens other stores. The listened stores subscriptions where being removed instead of the listener store subscriptions.

Tried to fix by passing the listener subscriptions to the unsubscriber function so they can be spliced correctly.
