### PR TITLE
module export fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reflux-core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A simple library for uni-directional dataflow application architecture inspired by ReactJS Flux",
   "main": "lib/index.js",
   "scripts": {

--- a/src/ActionMethods.js
+++ b/src/ActionMethods.js
@@ -2,6 +2,6 @@
  * A module of methods that you want to include in all actions.
  * This module is consumed by `createAction`.
  */
-const ActionMethods = {};
 
-export default ActionMethods;
+// if we actually add any then remove this export and export each method
+export {};

--- a/src/Keep.js
+++ b/src/Keep.js
@@ -31,4 +31,4 @@ function reset() {
     }
 }
 
-export default { useKeep, addStore, addAction, createdStores, createdActions, reset };
+export { useKeep, addStore, addAction, createdStores, createdActions, reset };

--- a/src/ListenerMethods.js
+++ b/src/ListenerMethods.js
@@ -44,177 +44,172 @@ var flattenListenables = function(listenables) {
     return flattened;
 };
 
+
 /**
- * A module of methods related to listening.
+ * An internal utility function used by `validateListening`
+ *
+ * @param {Action|Store} listenable The listenable we want to search for
+ * @returns {Boolean} The result of a recursive search among `this.subscriptions`
  */
-export default {
-
-    /**
-     * An internal utility function used by `validateListening`
-     *
-     * @param {Action|Store} listenable The listenable we want to search for
-     * @returns {Boolean} The result of a recursive search among `this.subscriptions`
-     */
-    hasListener: function(listenable) {
-        var i = 0, j, listener, listenables;
-        for (;i < (this.subscriptions || []).length; ++i) {
-            listenables = [].concat(this.subscriptions[i].listenable);
-            for (j = 0; j < listenables.length; j++){
-                listener = listenables[j];
-                if (listener === listenable || listener.hasListener && listener.hasListener(listenable)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    },
-
-    /**
-     * A convenience method that listens to all listenables in the given object.
-     *
-     * @param {Object} listenables An object of listenables. Keys will be used as callback method names.
-     */
-    listenToMany: function(listenables){
-        var allListenables = flattenListenables(listenables);
-        for(var key in allListenables){
-            var cbname = _.callbackName(key),
-                localname = this[cbname] ? cbname : this[key] ? key : undefined;
-            if (localname){
-                this.listenTo(allListenables[key], localname, this[cbname + "Default"] || this[localname + "Default"] || localname);
-            }
-        }
-    },
-
-    /**
-     * Checks if the current context can listen to the supplied listenable
-     *
-     * @param {Action|Store} listenable An Action or Store that should be
-     *  listened to.
-     * @returns {String|Undefined} An error message, or undefined if there was no problem.
-     */
-    validateListening: function(listenable){
-        if (listenable === this) {
-            return "Listener is not able to listen to itself";
-        }
-        if (!_.isFunction(listenable.listen)) {
-            return listenable + " is missing a listen method";
-        }
-        if (listenable.hasListener && listenable.hasListener(this)) {
-            return "Listener cannot listen to this listenable because of circular loop";
-        }
-    },
-
-    /**
-     * Sets up a subscription to the given listenable for the context object
-     *
-     * @param {Action|Store} listenable An Action or Store that should be
-     *  listened to.
-     * @param {Function|String} callback The callback to register as event handler
-     * @param {Function|String} defaultCallback The callback to register as default handler
-     * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is the object being listened to
-     */
-    listenTo: function(listenable, callback, defaultCallback) {
-        var desub, unsubscriber, subscriptionobj, subs = this.subscriptions = this.subscriptions || [];
-        _.throwIf(this.validateListening(listenable));
-        this.fetchInitialState(listenable, defaultCallback);
-        desub = listenable.listen(this[callback] || callback, this);
-        unsubscriber = function() {
-            var index = subs.indexOf(subscriptionobj);
-            _.throwIf(index === -1, "Tried to remove listen already gone from subscriptions list!");
-            subs.splice(index, 1);
-            desub();
-        };
-        subscriptionobj = {
-            stop: unsubscriber,
-            listenable: listenable
-        };
-        subs.push(subscriptionobj);
-        return subscriptionobj;
-    },
-
-    /**
-     * Stops listening to a single listenable
-     *
-     * @param {Action|Store} listenable The action or store we no longer want to listen to
-     * @returns {Boolean} True if a subscription was found and removed, otherwise false.
-     */
-    stopListeningTo: function(listenable){
-        var sub, i = 0, subs = this.subscriptions || [];
-        for(;i < subs.length; i++){
-            sub = subs[i];
-            if (sub.listenable === listenable){
-                sub.stop();
-                _.throwIf(subs.indexOf(sub) !== -1, "Failed to remove listen from subscriptions list!");
+export var hasListener = function(listenable) {
+    var i = 0, j, listener, listenables;
+    for (;i < (this.subscriptions || []).length; ++i) {
+        listenables = [].concat(this.subscriptions[i].listenable);
+        for (j = 0; j < listenables.length; j++){
+            listener = listenables[j];
+            if (listener === listenable || listener.hasListener && listener.hasListener(listenable)) {
                 return true;
             }
         }
-        return false;
-    },
-
-    /**
-     * Stops all subscriptions and empties subscriptions array
-     */
-    stopListeningToAll: function(){
-        var remaining, subs = this.subscriptions || [];
-        while((remaining = subs.length)){
-            subs[0].stop();
-            _.throwIf(subs.length !== remaining - 1, "Failed to remove listen from subscriptions list!");
-        }
-    },
-
-    /**
-     * Used in `listenTo`. Fetches initial data from a publisher if it has a `getInitialState` method.
-     * @param {Action|Store} listenable The publisher we want to get initial state from
-     * @param {Function|String} defaultCallback The method to receive the data
-     */
-    fetchInitialState: function (listenable, defaultCallback) {
-        defaultCallback = (defaultCallback && this[defaultCallback]) || defaultCallback;
-        var me = this;
-        if (_.isFunction(defaultCallback) && _.isFunction(listenable.getInitialState)) {
-            var data = listenable.getInitialState();
-            if (data && _.isFunction(data.then)) {
-                data.then(function() {
-                    defaultCallback.apply(me, arguments);
-                });
-            } else {
-                defaultCallback.call(this, data);
-            }
-        }
-    },
-
-    /**
-     * The callback will be called once all listenables have triggered at least once.
-     * It will be invoked with the last emission from each listenable.
-     * @param {...Publishers} publishers Publishers that should be tracked.
-     * @param {Function|String} callback The method to call when all publishers have emitted
-     * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is an array of listenables
-     */
-    joinTrailing: maker("last"),
-
-    /**
-     * The callback will be called once all listenables have triggered at least once.
-     * It will be invoked with the first emission from each listenable.
-     * @param {...Publishers} publishers Publishers that should be tracked.
-     * @param {Function|String} callback The method to call when all publishers have emitted
-     * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is an array of listenables
-     */
-    joinLeading: maker("first"),
-
-    /**
-     * The callback will be called once all listenables have triggered at least once.
-     * It will be invoked with all emission from each listenable.
-     * @param {...Publishers} publishers Publishers that should be tracked.
-     * @param {Function|String} callback The method to call when all publishers have emitted
-     * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is an array of listenables
-     */
-    joinConcat: maker("all"),
-
-    /**
-     * The callback will be called once all listenables have triggered.
-     * If a callback triggers twice before that happens, an error is thrown.
-     * @param {...Publishers} publishers Publishers that should be tracked.
-     * @param {Function|String} callback The method to call when all publishers have emitted
-     * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is an array of listenables
-     */
-    joinStrict: maker("strict")
+    }
+    return false;
 };
+
+/**
+ * A convenience method that listens to all listenables in the given object.
+ *
+ * @param {Object} listenables An object of listenables. Keys will be used as callback method names.
+ */
+export var listenToMany = function(listenables){
+    var allListenables = flattenListenables(listenables);
+    for(var key in allListenables){
+        var cbname = _.callbackName(key),
+            localname = this[cbname] ? cbname : this[key] ? key : undefined;
+        if (localname){
+            this.listenTo(allListenables[key], localname, this[cbname + "Default"] || this[localname + "Default"] || localname);
+        }
+    }
+};
+
+/**
+ * Checks if the current context can listen to the supplied listenable
+ *
+ * @param {Action|Store} listenable An Action or Store that should be
+ *  listened to.
+ * @returns {String|Undefined} An error message, or undefined if there was no problem.
+ */
+export var validateListening = function(listenable){
+    if (listenable === this) {
+        return "Listener is not able to listen to itself";
+    }
+    if (!_.isFunction(listenable.listen)) {
+        return listenable + " is missing a listen method";
+    }
+    if (listenable.hasListener && listenable.hasListener(this)) {
+        return "Listener cannot listen to this listenable because of circular loop";
+    }
+};
+
+/**
+ * Sets up a subscription to the given listenable for the context object
+ *
+ * @param {Action|Store} listenable An Action or Store that should be
+ *  listened to.
+ * @param {Function|String} callback The callback to register as event handler
+ * @param {Function|String} defaultCallback The callback to register as default handler
+ * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is the object being listened to
+ */
+export var listenTo = function(listenable, callback, defaultCallback) {
+    var desub, unsubscriber, subscriptionobj, subs = this.subscriptions = this.subscriptions || [];
+    _.throwIf(this.validateListening(listenable));
+    this.fetchInitialState(listenable, defaultCallback);
+    desub = listenable.listen(this[callback] || callback, this);
+    unsubscriber = function() {
+        var index = subs.indexOf(subscriptionobj);
+        _.throwIf(index === -1, "Tried to remove listen already gone from subscriptions list!");
+        subs.splice(index, 1);
+        desub();
+    };
+    subscriptionobj = {
+        stop: unsubscriber,
+        listenable: listenable
+    };
+    subs.push(subscriptionobj);
+    return subscriptionobj;
+};
+
+/**
+ * Stops listening to a single listenable
+ *
+ * @param {Action|Store} listenable The action or store we no longer want to listen to
+ * @returns {Boolean} True if a subscription was found and removed, otherwise false.
+ */
+export var stopListeningTo = function(listenable){
+    var sub, i = 0, subs = this.subscriptions || [];
+    for(;i < subs.length; i++){
+        sub = subs[i];
+        if (sub.listenable === listenable){
+            sub.stop();
+            _.throwIf(subs.indexOf(sub) !== -1, "Failed to remove listen from subscriptions list!");
+            return true;
+        }
+    }
+    return false;
+};
+
+/**
+ * Stops all subscriptions and empties subscriptions array
+ */
+export var stopListeningToAll = function(){
+    var remaining, subs = this.subscriptions || [];
+    while((remaining = subs.length)){
+        subs[0].stop();
+        _.throwIf(subs.length !== remaining - 1, "Failed to remove listen from subscriptions list!");
+    }
+};
+
+/**
+ * Used in `listenTo`. Fetches initial data from a publisher if it has a `getInitialState` method.
+ * @param {Action|Store} listenable The publisher we want to get initial state from
+ * @param {Function|String} defaultCallback The method to receive the data
+ */
+export var fetchInitialState = function(listenable, defaultCallback) {
+    defaultCallback = (defaultCallback && this[defaultCallback]) || defaultCallback;
+    var me = this;
+    if (_.isFunction(defaultCallback) && _.isFunction(listenable.getInitialState)) {
+        var data = listenable.getInitialState();
+        if (data && _.isFunction(data.then)) {
+            data.then(function() {
+                defaultCallback.apply(me, arguments);
+            });
+        } else {
+            defaultCallback.call(this, data);
+        }
+    }
+};
+
+/**
+ * The callback will be called once all listenables have triggered at least once.
+ * It will be invoked with the last emission from each listenable.
+ * @param {...Publishers} publishers Publishers that should be tracked.
+ * @param {Function|String} callback The method to call when all publishers have emitted
+ * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is an array of listenables
+ */
+export var joinTrailing = maker("last");
+
+/**
+ * The callback will be called once all listenables have triggered at least once.
+ * It will be invoked with the first emission from each listenable.
+ * @param {...Publishers} publishers Publishers that should be tracked.
+ * @param {Function|String} callback The method to call when all publishers have emitted
+ * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is an array of listenables
+ */
+export var joinLeading = maker("first");
+
+/**
+ * The callback will be called once all listenables have triggered at least once.
+ * It will be invoked with all emission from each listenable.
+ * @param {...Publishers} publishers Publishers that should be tracked.
+ * @param {Function|String} callback The method to call when all publishers have emitted
+ * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is an array of listenables
+ */
+export var joinConcat = maker("all");
+
+/**
+ * The callback will be called once all listenables have triggered.
+ * If a callback triggers twice before that happens, an error is thrown.
+ * @param {...Publishers} publishers Publishers that should be tracked.
+ * @param {Function|String} callback The method to call when all publishers have emitted
+ * @returns {Object} A subscription obj where `stop` is an unsub function and `listenable` is an array of listenables
+ */
+export var joinStrict = maker("strict");

--- a/src/PublisherMethods.js
+++ b/src/PublisherMethods.js
@@ -4,87 +4,84 @@ import * as _ from "./utils";
  * A module of methods for object that you want to be able to listen to.
  * This module is consumed by `createStore` and `createAction`
  */
-export default {
 
-    /**
-     * Hook used by the publisher that is invoked before emitting
-     * and before `shouldEmit`. The arguments are the ones that the action
-     * is invoked with. If this function returns something other than
-     * undefined, that will be passed on as arguments for shouldEmit and
-     * emission.
-     */
-    preEmit: function() {},
+/**
+ * Hook used by the publisher that is invoked before emitting
+ * and before `shouldEmit`. The arguments are the ones that the action
+ * is invoked with. If this function returns something other than
+ * undefined, that will be passed on as arguments for shouldEmit and
+ * emission.
+ */
+export var preEmit = function() {};
 
-    /**
-     * Hook used by the publisher after `preEmit` to determine if the
-     * event should be emitted with given arguments. This may be overridden
-     * in your application, default implementation always returns true.
-     *
-     * @returns {Boolean} true if event should be emitted
-     */
-    shouldEmit: function() { return true; },
+/**
+ * Hook used by the publisher after `preEmit` to determine if the
+ * event should be emitted with given arguments. This may be overridden
+ * in your application, default implementation always returns true.
+ *
+ * @returns {Boolean} true if event should be emitted
+ */
+export var shouldEmit = function() { return true; };
 
-    /**
-     * Subscribes the given callback for action triggered
-     *
-     * @param {Function} callback The callback to register as event handler
-     * @param {Mixed} [optional] bindContext The context to bind the callback with
-     * @returns {Function} Callback that unsubscribes the registered event handler
-     */
-    listen: function(callback, bindContext) {
-        bindContext = bindContext || this;
-        var eventHandler = function(args) {
-            if (aborted){
-                return;
-            }
-            callback.apply(bindContext, args);
-        }, me = this, aborted = false;
-        this.emitter.addListener(this.eventLabel, eventHandler);
-        return function() {
-            aborted = true;
-            me.emitter.removeListener(me.eventLabel, eventHandler);
-        };
-    },
-
-    /**
-     * Publishes an event using `this.emitter` (if `shouldEmit` agrees)
-     */
-    trigger: function() {
-        var args = arguments,
-            pre = this.preEmit.apply(this, args);
-        args = pre === undefined ? args : _.isArguments(pre) ? pre : [].concat(pre);
-        if (this.shouldEmit.apply(this, args)) {
-            this.emitter.emit(this.eventLabel, args);
+/**
+ * Subscribes the given callback for action triggered
+ *
+ * @param {Function} callback The callback to register as event handler
+ * @param {Mixed} [optional] bindContext The context to bind the callback with
+ * @returns {Function} Callback that unsubscribes the registered event handler
+ */
+export var listen = function(callback, bindContext) {
+    bindContext = bindContext || this;
+    var eventHandler = function(args) {
+        if (aborted){
+            return;
         }
-    },
+        callback.apply(bindContext, args);
+    }, me = this, aborted = false;
+    this.emitter.addListener(this.eventLabel, eventHandler);
+    return function() {
+        aborted = true;
+        me.emitter.removeListener(me.eventLabel, eventHandler);
+    };
+};
 
-    /**
-     * Tries to publish the event on the next tick
-     */
-    triggerAsync: function(){
-        var args = arguments, me = this;
-        _.nextTick(function() {
-            me.trigger.apply(me, args);
-        });
-    },
-
-    /**
-     * Wraps the trigger mechanism with a deferral function.
-     *
-     * @param {Function} callback the deferral function,
-     *        first argument is the resolving function and the
-     *        rest are the arguments provided from the previous
-     *        trigger invocation
-     */
-    deferWith: function(callback) {
-        var oldTrigger = this.trigger,
-            ctx = this,
-            resolver = function() {
-                oldTrigger.apply(ctx, arguments);
-            };
-        this.trigger = function() {
-            callback.apply(ctx, [resolver].concat([].splice.call(arguments, 0)));
-        };
+/**
+ * Publishes an event using `this.emitter` (if `shouldEmit` agrees)
+ */
+export var trigger = function() {
+    var args = arguments,
+        pre = this.preEmit.apply(this, args);
+    args = pre === undefined ? args : _.isArguments(pre) ? pre : [].concat(pre);
+    if (this.shouldEmit.apply(this, args)) {
+        this.emitter.emit(this.eventLabel, args);
     }
+};
 
+/**
+ * Tries to publish the event on the next tick
+ */
+export var triggerAsync = function(){
+    var args = arguments, me = this;
+    _.nextTick(function() {
+        me.trigger.apply(me, args);
+    });
+};
+
+/**
+ * Wraps the trigger mechanism with a deferral function.
+ *
+ * @param {Function} callback the deferral function,
+ *        first argument is the resolving function and the
+ *        rest are the arguments provided from the previous
+ *        trigger invocation
+ */
+export var deferWith = function(callback) {
+    var oldTrigger = this.trigger,
+        ctx = this,
+        resolver = function() {
+            oldTrigger.apply(ctx, arguments);
+        };
+    this.trigger = function() {
+        callback.apply(ctx, [resolver].concat([].splice.call(arguments, 0)));
+    };
 };

--- a/src/StoreMethods.js
+++ b/src/StoreMethods.js
@@ -2,6 +2,6 @@
  * A module of methods that you want to include in all stores.
  * This module is consumed by `createStore`.
  */
-const StoreMethods = {};
 
-export default StoreMethods;
+// if we actually add any then remove this export and export each method
+export {};

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -1,7 +1,7 @@
 import * as _ from "./utils";
-import ActionMethods from "./ActionMethods";
-import PublisherMethods from "./PublisherMethods";
-import Keep from "./Keep";
+import * as ActionMethods from "./ActionMethods";
+import * as PublisherMethods from "./PublisherMethods";
+import * as Keep from "./Keep";
 
 var allowed = { preEmit: 1, shouldEmit: 1 };
 
@@ -12,7 +12,7 @@ var allowed = { preEmit: 1, shouldEmit: 1 };
  *
  * @param {Object} definition The action object definition
  */
-export default function createAction(definition) {
+export function createAction(definition) {
 
     definition = definition || {};
     if (!_.isObject(definition)){

--- a/src/createStore.js
+++ b/src/createStore.js
@@ -1,10 +1,10 @@
 import * as _ from "./utils";
-import Keep from "./Keep";
-import mixer from "./mixer";
-import { bindMethods } from "./bindMethods";
-import { default as StoreMethods } from "./StoreMethods";
-import { default as PublisherMethods } from "./PublisherMethods";
-import { default as ListenerMethods } from "./ListenerMethods";
+import * as Keep from "./Keep";
+import {mix as mixer} from "./mixer";
+import {bindMethods} from "./bindMethods";
+import * as StoreMethods from "./StoreMethods";
+import * as PublisherMethods from "./PublisherMethods";
+import * as ListenerMethods from "./ListenerMethods";
 
 var allowed = { preEmit: 1, shouldEmit: 1 };
 
@@ -16,7 +16,7 @@ var allowed = { preEmit: 1, shouldEmit: 1 };
  * @param {Object} definition The data store object definition
  * @returns {Store} A data store instance
  */
-export default function createStore(definition) {
+export function createStore(definition) {
 
     definition = definition || {};
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,10 @@ const version = {
     "reflux-core": "@VERSION"
 };
 
-import ActionMethods from "./ActionMethods";
-import ListenerMethods from "./ListenerMethods";
-import PublisherMethods from "./PublisherMethods";
-import StoreMethods from "./StoreMethods";
+import * as ActionMethods from "./ActionMethods";
+import * as ListenerMethods from "./ListenerMethods";
+import * as PublisherMethods from "./PublisherMethods";
+import * as StoreMethods from "./StoreMethods";
 
 import { staticJoinCreator as maker} from "./joins";
 const joinTrailing = maker("last");
@@ -16,8 +16,8 @@ const joinConcat = maker("all");
 
 import * as _ from "./utils";
 const utils = _;
-import createAction from "./createAction";
-import createStore from "./createStore";
+import {createAction} from "./createAction";
+import {createStore} from "./createStore";
 
 /**
  * Convenience function for creating a set of actions
@@ -72,9 +72,9 @@ function use (pluginCb) {
  * Provides the set of created actions and stores for introspection
  */
 /*eslint-disable no-underscore-dangle*/
-import __keep from "./Keep";
+import * as __keep from "./Keep";
 
-export default {
+export {
     version,
     ActionMethods,
     ListenerMethods,

--- a/src/joins.js
+++ b/src/joins.js
@@ -2,7 +2,7 @@
  * Internal module used to create static and instance join methods
  */
 
-import createStore from "./createStore";
+import {createStore} from "./createStore";
 import * as _ from "./utils";
 
 var slice = Array.prototype.slice,

--- a/src/mixer.js
+++ b/src/mixer.js
@@ -1,6 +1,6 @@
 import * as _ from "./utils";
 
-export default function mix(def) {
+export function mix(def) {
     var composed = {
         init: [],
         preEmit: [],

--- a/test/addPlugins.spec.js
+++ b/test/addPlugins.spec.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
-import Reflux from '../src';
+import * as Reflux from '../src';
 
 describe('add plugins with use function', function() {
 

--- a/test/ceasingListens.spec.js
+++ b/test/ceasingListens.spec.js
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
-import Store from '../src/createStore';
-import Action from '../src/createAction';
+import {createStore as Store} from '../src/createStore';
+import {createAction as Action} from '../src/createAction';
 
 var fn = function(){};
 

--- a/test/changingEventStore.spec.js
+++ b/test/changingEventStore.spec.js
@@ -1,6 +1,6 @@
 import chai, { assert } from 'chai';
 import asPromised from 'chai-as-promised';
-import { default as Reflux } from '../src';
+import * as Reflux from '../src';
 import * as internalUtils from '../src/utils';
 
 chai.use(asPromised);

--- a/test/composedListenable.spec.js
+++ b/test/composedListenable.spec.js
@@ -1,7 +1,7 @@
 import Q from 'q';
 import chai, { assert } from 'chai';
 import asPromised from 'chai-as-promised';
-import { default as Reflux } from '../src';
+import * as Reflux from '../src';
 import * as _ from '../src/utils';
 
 chai.use(asPromised);

--- a/test/creatingActions.spec.js
+++ b/test/creatingActions.spec.js
@@ -2,7 +2,7 @@ import Q from 'q';
 import chai, { assert } from 'chai';
 import asPromised from 'chai-as-promised';
 import sinon from 'sinon';
-import Reflux from '../src';
+import * as Reflux from '../src';
 
 chai.use(asPromised);
 

--- a/test/creatingAggregateStores.spec.js
+++ b/test/creatingAggregateStores.spec.js
@@ -1,7 +1,7 @@
 import Q from 'q';
 import chai, { assert } from 'chai';
 import asPromised from 'chai-as-promised';
-import { default as Reflux } from '../src';
+import * as Reflux from '../src';
 
 chai.use(asPromised);
 

--- a/test/creatingStores.spec.js
+++ b/test/creatingStores.spec.js
@@ -2,7 +2,7 @@ import Q from 'q';
 import chai, { assert } from 'chai';
 import asPromised from 'chai-as-promised';
 import sinon from 'sinon';
-import Reflux from '../src';
+import * as Reflux from '../src';
 import * as _ from '../src/utils';
 
 chai.use(asPromised);

--- a/test/inspectWithKeep.spec.js
+++ b/test/inspectWithKeep.spec.js
@@ -1,5 +1,5 @@
 import { assert } from 'chai';
-import { default as Reflux } from '../src';
+import * as Reflux from '../src';
 
 describe('with the keep reset', function() {
     beforeEach(function () {

--- a/test/overridingEmitHooks.spec.js
+++ b/test/overridingEmitHooks.spec.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
-import Reflux from '../src';
+import * as Reflux from '../src';
 
 describe("overriding preEmit",function(){
     describe("for lone action",function(){

--- a/test/storeMixins.spec.js
+++ b/test/storeMixins.spec.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
-import Reflux from '../src';
+import * as Reflux from '../src';
 
 describe('Creating stores with mixins', function () {
     describe('with one simple mixin', function () {

--- a/test/usingDeferWith.spec.js
+++ b/test/usingDeferWith.spec.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
-import { default as Reflux } from '../src';
+import * as Reflux from '../src';
 
 describe('using deferWith function', function() {
 

--- a/test/usingJoins.spec.js
+++ b/test/usingJoins.spec.js
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import sinon from 'sinon';
-import Reflux from '../src';
+import * as Reflux from '../src';
 
 describe('using joins',function(){
     describe('with static methods',function(){

--- a/test/usingPublisherMethodsMixin.spec.js
+++ b/test/usingPublisherMethodsMixin.spec.js
@@ -1,7 +1,7 @@
 import chai, { assert } from 'chai';
 import asPromised from 'chai-as-promised';
 import sinon from 'sinon';
-import Reflux from '../src';
+import * as Reflux from '../src';
 
 chai.use(asPromised);
 


### PR DESCRIPTION
Between the original 0.3.0 release and now this was converted to ES6 type importing exporting. Within itself this went fine, because the whole thing was changed. But this was done without realizing that it can drastically change the export output (such as from things like `{...}` to `{default:{...}}`) making outside packages that import `reflux-core` have incorrect expectations of input.

This fixes those exports to properly match what `reflux-core` exported before that switch.