### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test/
 tmp/
 src/
 scripts/
+.babelrc


### PR DESCRIPTION
Your `.babelrc` is breaking my `react-native` project (https://github.com/facebook/react-native/issues/8296). Please consider ignoring your .babelrc file as I don't believe you need it in your npm module.